### PR TITLE
Fixes #24: Support for Sql Server dialect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 /packages/**/generated
 *.tsbuildinfo
 /test/customers/
+/.idea*

--- a/package-lock.json
+++ b/package-lock.json
@@ -3320,7 +3320,7 @@
       }
     },
     "packages/langium-sql": {
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "langium": "~1.1.0",
@@ -3332,10 +3332,10 @@
       }
     },
     "packages/langium-sql-vscode": {
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
-        "langium-sql": "0.2.3",
+        "langium-sql": "0.2.4",
         "vscode-languageclient": "^8.0.2"
       },
       "devDependencies": {
@@ -4750,7 +4750,7 @@
       "requires": {
         "@types/vscode": "^1.67.0",
         "esbuild": "^0.16.14",
-        "langium-sql": "0.2.3",
+        "langium-sql": "0.2.4",
         "vscode-languageclient": "^8.0.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3332,7 +3332,7 @@
       }
     },
     "packages/langium-sql-vscode": {
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "langium-sql": "0.2.3",

--- a/packages/langium-sql-vscode/package.json
+++ b/packages/langium-sql-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "langium-sql-vscode",
   "displayName": "SQL Extension",
   "description": "Language server extension for SQL",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publisher": "langium",
   "license": "MIT",
   "engines": {
@@ -46,7 +46,7 @@
     "lint": "eslint src --ext ts"
   },
   "dependencies": {
-    "langium-sql": "0.2.3",
+    "langium-sql": "0.2.4",
     "vscode-languageclient": "^8.0.2"
   },
   "devDependencies": {

--- a/packages/langium-sql-vscode/syntaxes/sql.tmLanguage.json
+++ b/packages/langium-sql-vscode/syntaxes/sql.tmLanguage.json
@@ -13,16 +13,6 @@
       "match": "\\b([aA][lL][lL]|[aA][nN][dD]|[aA][sS]|[aA][sS][cC]|[bB][eE][tT][wW][eE][eE][nN]|[bB][yY]|[cC][aA][sS][cC][aA][dD][eE]|[cC][aA][sS][tT]|[cC][aA][tT][aA][lL][oO][gG]|[cC][oO][nN][sS][tT][rR][aA][iI][nN][tT]|[cC][rR][eE][aA][tT][eE]|[cC][uU][rR][rR][eE][nN][tT]|[dD][aA][tT][aA][bB][aA][sS][eE]|[dD][eE][lL][eE][tT][eE]|[dD][eE][sS][cC]|[dD][iI][sS][tT][iI][nN][cC][tT]|[eE][xX][cC][eE][pP][tT]|[fF][aA][lL][sS][eE]|[fF][eE][tT][cC][hH]|[fF][iI][rR][sS][tT]|[fF][oO][lL][lL][oO][wW][iI][nN][gG]|[fF][oO][rR][eE][iI][gG][nN]|[fF][rR][oO][mM]|[fF][uU][nN][cC][tT][iI][oO][nN]|[gG][rR][oO][uU][pP]|[hH][aA][vV][iI][nN][gG]|[iI][nN]|[iI][nN][dD][eE][xX]|[iI][nN][tT][eE][rR][sS][eE][cC][tT]|[iI][sS]|[jJ][oO][iI][nN]|[kK][eE][yY]|[lL][eE][fF][tT]|[lL][iI][kK][eE]|[lL][iI][mM][iI][tT]|[mM][iI][nN][uU][sS]|[nN][eE][xX][tT]|[nN][oO][tT]|[nN][uU][lL][lL]|[oO][fF][fF][sS][eE][tT]|[oO][nN]|[oO][nN][lL][yY]|[oO][rR]|[oO][rR][dD][eE][rR]|[oO][vV][eE][rR]|[pP][aA][rR][tT][iI][tT][iI][oO][nN]|[pP][eE][rR][cC][eE][nN][tT]|[pP][rR][eE][cC][eE][dD][iI][nN][gG]|[pP][rR][iI][mM][aA][rR][yY]|[rR][aA][nN][gG][eE]|[rR][eE][cC][uU][rR][sS][iI][vV][eE]|[rR][eE][fF][eE][rR][eE][nN][cC][eE][sS]|[rR][eE][pP][lL][aA][cC][eE]|[rR][iI][gG][hH][tT]|[rR][oO][wW]|[rR][oO][wW][sS]|[sS][cC][hH][eE][mM][aA]|[sS][eE][lL][eE][cC][tT]|[tT][aA][bB][lL][eE]|[tT][iI][eE][sS]|[tT][oO][pP]|[tT][rR][uU][eE]|[uU][nN][bB][oO][uU][nN][dD][eE][dD]|[uU][nN][iI][oO][nN]|[uU][nN][iI][qQ][uU][eE]|[uU][sS][iI][nN][gG]|[wW][hH][eE][rR][eE]|[wW][iI][tT][hH])\\b"
     },
     {
-      "name": "string.quoted.double.sql",
-      "begin": "\"",
-      "end": "\"",
-      "patterns": [
-        {
-          "include": "#string-character-escape"
-        }
-      ]
-    },
-    {
       "name": "string.quoted.single.sql",
       "begin": "'",
       "end": "'",

--- a/packages/langium-sql/package.json
+++ b/packages/langium-sql/package.json
@@ -2,7 +2,7 @@
   "name": "langium-sql",
   "displayName": "SQL Language Server",
   "description": "Extensible language server for SQL",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "MIT",
   "files": [
     "lib",

--- a/packages/langium-sql/src/sql.langium
+++ b/packages/langium-sql/src/sql.langium
@@ -310,7 +310,7 @@ CastExpression:
 type ColumnNameSource = ColumnDefinition | ExpressionQuery;
 
 Identifier returns string:
-    ID | TICK_STRING
+    ID | QUOTED_ID | TICK_STRING | BRACKET_STRING
 ;
 
 NumberLiteral:
@@ -331,8 +331,10 @@ DataTypeArgument:
 
 hidden terminal WS: /\s+/;
 terminal HEX_STRING returns string: /x\'[A-Fa-f0-9]+\'/;
-terminal STRING returns string: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
+terminal STRING returns string: /'(\\.|[^'\\])*'/;
 terminal TICK_STRING returns string: /\`(\\.|\\\\|[^`\\])*\`/;
+terminal BRACKET_STRING returns string:    /\[(\\.|\\\\|[^[\\])*\]/;
+terminal QUOTED_ID returns string: /\"(\\.|\\\\|[^"\\])*\"/;
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal NUMBER returns number: /\d+((\.\d+)?([eE][\-+]?\d+)?)?/;
 

--- a/packages/langium-sql/test/syntax/create-table-syntax.test.ts
+++ b/packages/langium-sql/test/syntax/create-table-syntax.test.ts
@@ -30,6 +30,8 @@ describe('CREATE TABLE syntax coverage', () => {
     }
 
     it('Simple CREATE TABLE', () => expectParseable('CREATE TABLE X(Y int);'));
+    it('Simple CREATE TABLE with bracket escaped identifier', () => expectParseable('CREATE TABLE X([Rule] int);'));
+    it('Simple CREATE TABLE with tick escaped identifier', () => expectParseable('CREATE TABLE X(`Rule` int);'));
     it('Simple CREATE TABLE with multiple columns', () => expectParseable('CREATE TABLE X(Y int, Z real);'));
     it('Simple CREATE TABLE with nullable column', () => expectParseable('CREATE TABLE X(Y int NULL);'));
     it('Simple CREATE TABLE with non-nullable column', () => expectParseable('CREATE TABLE X(Y int NOT NULL);'));

--- a/packages/langium-sql/test/types/type-system.test.ts
+++ b/packages/langium-sql/test/types/type-system.test.ts
@@ -108,8 +108,8 @@ describe("Type system", () => {
         expectSelectItemsToBeOfType(typeComputer, selectStatement, [Types.Char()]);
         expectSelectItemsToHaveNames(selectStatement, [undefined]);
     });
-    it("::$ operator with StringLiteral", async () => {
-        const document = await parse(`SELECT firstname::\$"string" FROM passenger;`);
+    it("::$ operator with a Quoted Identifier", async () => {
+        const document = await parse(`SELECT firstname::\$[string] FROM passenger;`);
         const selectStatement = asSelectTableExpression(document);
         expectNoErrors(document);
         expectSelectItemsToBeOfType(typeComputer, selectStatement, [Types.Char()]);


### PR DESCRIPTION
- Double quoted and Bracketed strings parsed as Quoted Identifiers
- Double quotes no longer parsed as literals